### PR TITLE
fix: incorrect site config request id

### DIFF
--- a/src/pages/manage/SiteSetting.tsx
+++ b/src/pages/manage/SiteSetting.tsx
@@ -22,14 +22,10 @@ export default () => {
     }
 
     if (defaultSiteConfig?.id && defaultSiteConfig?.siteInfo?.id) {
-      const siteConfigRequest = modifySiteConfigSetting(
-        defaultSiteConfig.siteInfo.id,
-        defaultSiteConfig.id,
-        {
-          language: values.language,
-          timezone: values.timezone,
-        },
-      );
+      const siteConfigRequest = modifySiteConfigSetting(defaultSiteConfig.id, {
+        language: values.language,
+        timezone: values.timezone,
+      });
 
       const siteInfoRequest = modifySiteInfoSetting(defaultSiteConfig.siteInfo.id, {
         title: values.title,


### PR DESCRIPTION
# Pull Request Template

## Type of change

<!-- Please put an `x` in boxes that apply. -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Does this PR requires a change to the documentation?** (check one)

- [ ] Yes
- [x] No

If yes, please update the documentation accordingly.

## Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

<!-- If adding a **new feature**, please include a convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it). -->

Fixes incorrect config id, it should be config id but it was the id of the site info.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Have tested this part of the code already by using its feature.

**Desktop:** 
<!-- Please complete the following information -->
<!-- Or paste your full system/browser infomation, e.g. the output of `uname -a`  -->
<!-- Darwin MacPro 20.6.0 Darwin Kernel Version 20.6.0 ... arm64  -->

> Darwin MacPro 20.6.0 Darwin Kernel Version 20.6.0: Wed Jun 23 00:26:27 PDT 2021; root:xnu-7195.141.2~5/RELEASE_ARM64_T8101 arm64

 - OS:
   - [ ] Windows [version]
   - [x] macOS Big Sur 11.5
   - [ ] Linux [version]
 - Browser: Chrome 94.0.4606.81 (arm64)

**Smartphone:**

No adaptation.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.